### PR TITLE
feat(grupo): Implementação da  adição de membro ao grupo

### DIFF
--- a/src/main/java/com/divertech/raxae/auth/config/DataSeeder.java
+++ b/src/main/java/com/divertech/raxae/auth/config/DataSeeder.java
@@ -1,0 +1,58 @@
+package com.divertech.raxae.auth.config;
+
+import com.divertech.raxae.usuario.application.repository.UsuarioRepository;
+import com.divertech.raxae.usuario.domain.Usuario;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Profile("dev")
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class DataSeeder implements CommandLineRunner {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (usuarioRepository.count() == 0) {
+            log.info("Banco de dados vazio. Populando com dados iniciais de teste...");
+            createUsers();
+        } else {
+            log.info("Banco de dados já contém dados. O Seeder não será executado.");
+        }
+    }
+
+    private void createUsers() {
+        Usuario admin = Usuario.builder()
+                .nomeCompleto("Admin Teste")
+                .email("email.do.admin@teste.com")
+                .senha(passwordEncoder.encode("senhaDoAdmin"))
+                .whatsapp("99999999999")
+                .build();
+
+        Usuario naoAdmin = Usuario.builder()
+                .nomeCompleto("Usuario Comum")
+                .email("email.comum@teste.com")
+                .senha(passwordEncoder.encode("senhaComum"))
+                .whatsapp("88888888888")
+                .build();
+
+        Usuario novoMembro = Usuario.builder()
+                .nomeCompleto("Novo Membro")
+                .email("email.novo.membro@teste.com")
+                .senha(passwordEncoder.encode("senhaNovoMembro"))
+                .whatsapp("77777777777")
+                .build();
+        
+        usuarioRepository.saveAll(List.of(admin, naoAdmin, novoMembro));
+        
+        log.info("Usuários de teste criados com sucesso!");
+    }
+}

--- a/src/main/java/com/divertech/raxae/auth/config/service/AuthApplicationService.java
+++ b/src/main/java/com/divertech/raxae/auth/config/service/AuthApplicationService.java
@@ -1,21 +1,21 @@
 package com.divertech.raxae.auth.config.service;
 
-import com.divertech.raxae.usuario.application.controller.LoginRequest;
 import com.divertech.raxae.auth.domain.Token;
+import com.divertech.raxae.usuario.application.controller.LoginRequest;
 import com.divertech.raxae.usuario.application.repository.UsuarioRepository;
 import com.divertech.raxae.usuario.domain.Usuario;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.hibernate.validator.internal.util.stereotypes.Lazy;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Log4j2
 public class AuthApplicationService implements AuthService {
+
     private final UsuarioRepository usuarioRepository;
     private final JwtService jwtService;
     private final @Lazy AuthenticationManager authenticationManager;
@@ -24,7 +24,7 @@ public class AuthApplicationService implements AuthService {
     public Token login(LoginRequest request) {
         log.info("[start] AuthApplicationService - login");
         autentica(request);
-        Usuario usuario = usuarioRepository.buscaUsuario(request.getEmail());
+        Usuario usuario = usuarioRepository.buscaUsuarioPorEmail(request.getEmail());
         String token = jwtService.gerarToken(usuario);
         log.debug("[finish] AuthApplicationService - login");
         return new Token("Bearer", token, usuario.getId());
@@ -33,7 +33,7 @@ public class AuthApplicationService implements AuthService {
     @Override
     public Usuario buscaCredencialPorUsuario(String email) {
         log.info("[start] AuthApplicationService - buscaCredencialPorUsuario");
-        Usuario usuario = usuarioRepository.buscaUsuario(email);
+        Usuario usuario = usuarioRepository.buscaUsuarioPorEmail(email);
         log.debug("[finish] AuthApplicationService - buscaCredencialPorUsuario");
         return usuario;
     }

--- a/src/main/java/com/divertech/raxae/auth/config/service/UsuarioDetailsService.java
+++ b/src/main/java/com/divertech/raxae/auth/config/service/UsuarioDetailsService.java
@@ -15,6 +15,6 @@ public class UsuarioDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return usuarioRepository.buscaUsuario(email);
+        return usuarioRepository.buscaUsuarioPorEmail(email.toLowerCase());
     }
 }

--- a/src/main/java/com/divertech/raxae/grupo/application/controller/AdicionarMembroRequest.java
+++ b/src/main/java/com/divertech/raxae/grupo/application/controller/AdicionarMembroRequest.java
@@ -1,0 +1,10 @@
+package com.divertech.raxae.grupo.application.controller;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdicionarMembroRequest(
+    @NotBlank(message = "O e-mail não pode ser nulo ou vazio.")
+    @Email(message = "O formato do e-mail é inválido.")
+    String email
+) {}

--- a/src/main/java/com/divertech/raxae/grupo/application/controller/GrupoResponse.java
+++ b/src/main/java/com/divertech/raxae/grupo/application/controller/GrupoResponse.java
@@ -1,24 +1,52 @@
 package com.divertech.raxae.grupo.application.controller;
 
 import com.divertech.raxae.grupo.domain.Grupo;
-import lombok.AllArgsConstructor;
+import com.divertech.raxae.grupo.domain.Membro;
+import com.divertech.raxae.grupo.domain.StatusParticipacao;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Getter
-
+@ToString
 public class GrupoResponse {
-    private String idGrupo;
+    private UUID id;
     private String nomeGrupo;
     private String descricao;
     private String icone;
-    private String idUserAdmin;
+    private UUID adminId;
+    private LocalDateTime dataCriacao;
+    private Set<MembroResponse> membros;
 
     public GrupoResponse(Grupo grupo) {
-        this.idGrupo = grupo.getId().toString();
+        this.id = grupo.getId();
         this.nomeGrupo = grupo.getNomeGrupo();
         this.descricao = grupo.getDescricao();
         this.icone = grupo.getIcone();
-        this.idUserAdmin = grupo.getAdminId().toString();
+        this.adminId = grupo.getAdminId();
+        this.dataCriacao = grupo.getDataCriacao();
+        this.membros = grupo.getMembros().stream()
+                .map(MembroResponse::new)
+                .collect(Collectors.toSet());
+    }
+
+    @Getter
+    @ToString
+    private static class MembroResponse {
+        private UUID idMembro;
+        private UUID idUsuario;
+        private String nomeUsuario;
+        private StatusParticipacao status;
+
+        MembroResponse(Membro membro) {
+            this.idMembro = membro.getId();
+            this.idUsuario = membro.getUsuario().getId();
+            this.nomeUsuario = membro.getUsuario().getNomeCompleto();
+            this.status = membro.getStatus();
+        }
     }
 }

--- a/src/main/java/com/divertech/raxae/grupo/application/service/GrupoApplicationService.java
+++ b/src/main/java/com/divertech/raxae/grupo/application/service/GrupoApplicationService.java
@@ -1,28 +1,42 @@
 package com.divertech.raxae.grupo.application.service;
 
-import com.divertech.raxae.auth.config.service.JwtService;
 import com.divertech.raxae.grupo.application.controller.GrupoEditaRequest;
 import com.divertech.raxae.grupo.application.controller.GrupoNovoRequest;
 import com.divertech.raxae.grupo.application.controller.GrupoResponse;
 import com.divertech.raxae.grupo.application.repository.GrupoRepository;
 import com.divertech.raxae.grupo.domain.Grupo;
 import com.divertech.raxae.handler.APIException;
+import com.divertech.raxae.usuario.application.repository.UsuarioRepository;
+import com.divertech.raxae.usuario.domain.Usuario;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Log4j2
 public class GrupoApplicationService implements GrupoService {
-    private final GrupoRepository grupoRepository;
-    private final JwtService jwtService;
 
+    private final GrupoRepository grupoRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Override
+    @Transactional
+    public GrupoResponse criaGrupo(GrupoNovoRequest grupoRequest) {
+        log.info("[start] GrupoApplicationService - criaGrupo");
+        Usuario admin = usuarioRepository.buscaUsuarioPorId(UUID.fromString(grupoRequest.getIdUserAdmin()));
+        Grupo grupo = new Grupo(grupoRequest);
+        grupo.setAdministrador(admin);
+        grupoRepository.salva(grupo);
+        log.debug("[finish] GrupoApplicationService - criaGrupo");
+        return new GrupoResponse(grupo);
+    }
+
+    @Override
     @Transactional
     public void deletarGrupo(UUID idDoGrupo, UUID idUsuarioAtual) {
         log.info("[start] GrupoApplicationService - deletarGrupo");
@@ -33,49 +47,58 @@ public class GrupoApplicationService implements GrupoService {
     }
 
     @Override
-    public GrupoResponse criaGrupo(GrupoNovoRequest grupoRequest) {
-        log.info("[start] GrupoApplicationService - criaGrupo");
-        Grupo grupo = new Grupo(grupoRequest);
-        grupoRepository.salva(grupo);
-        GrupoResponse grupoResponse = new GrupoResponse(grupo);
-        log.debug("[finish] GrupoApplicationService - criaGrupo");
-        return grupoResponse;
-    }
-
-    @Override
-    public GrupoResponse getGrupoById(UUID idDoGrupo, UUID id) {
+    public GrupoResponse getGrupoById(UUID idDoGrupo, UUID idUsuarioAtual) {
         log.info("[start] GrupoApplicationService - getGrupoById");
         Grupo grupo = grupoRepository.buscaGrupoPorId(idDoGrupo);
-        GrupoResponse grupoResponse = new GrupoResponse(grupo);
-        log.debug("[finish] GrupoApplicationService - getGrupoById");
-        return grupoResponse;
+        //Futuramente, pode-se adicionar uma lógica para verificar
+        // se o usuário atual é membro do grupo antes de retornar os dados.
+        return new GrupoResponse(grupo);
     }
 
     @Override
-    public void editarGrupo(UUID idDoGrupo, GrupoEditaRequest grupoEditaRequest, UUID id) {
+    @Transactional
+    public void editarGrupo(UUID idDoGrupo, GrupoEditaRequest grupoEditaRequest, UUID idUsuarioAtual) {
         log.info("[start] GrupoApplicationService - editarGrupo");
         Grupo grupo = grupoRepository.buscaGrupoPorId(idDoGrupo);
-        log.info("Puxando Info do User:");
-        log.info(grupo.getAdminId() + "Id do Admin");
-        log.info(id + "Id do User Atual");
-        possuiPermissaoDeAdmin(id, grupo);
-        grupoRepository.editarGrupo(idDoGrupo, grupoEditaRequest);
+        possuiPermissaoDeAdmin(idUsuarioAtual, grupo);
+        grupo.atualizaInformacoes(grupoEditaRequest);
+        grupoRepository.salva(grupo);
         log.debug("[finish] GrupoApplicationService - editarGrupo");
     }
 
     @Override
-    public void removerMembro(UUID idDoGrupo, UUID idDoMembro, UUID id) {
+    @Transactional
+    public void removerMembro(UUID idDoGrupo, UUID idDoMembro, UUID idUsuarioAtual) {
         log.info("[start] GrupoApplicationService - removerMembro");
         Grupo grupo = grupoRepository.buscaGrupoPorId(idDoGrupo);
-        possuiPermissaoDeAdmin(id, grupo);
+        possuiPermissaoDeAdmin(idUsuarioAtual, grupo);
         grupo.removeMembro(idDoMembro);
         grupoRepository.salva(grupo);
         log.debug("[finish] GrupoApplicationService - removerMembro");
     }
 
-    private static void possuiPermissaoDeAdmin(UUID idUsuarioAtual, Grupo grupo) {
+    @Override
+    @Transactional
+    public void adicionarMembro(UUID idGrupo, String emailNovoMembro) {
+        log.info("[start] GrupoApplicationService - adicionarMembro");
+        Grupo grupo = grupoRepository.buscaGrupoPorId(idGrupo);
+
+        String adminEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        if (!grupo.isAdmin(adminEmail)) {
+            throw APIException.build(HttpStatus.FORBIDDEN, "Apenas o administrador pode adicionar novos membros.");
+        }
+
+        Usuario usuarioParaAdicionar = usuarioRepository.buscaUsuarioPorEmail(emailNovoMembro.toLowerCase());
+        grupo.adicionaNovoMembro(usuarioParaAdicionar);
+        grupoRepository.salva(grupo);
+
+        log.info("Simulando envio de notificação de convite para {}", emailNovoMembro);
+        log.info("[finish] GrupoApplicationService - adicionarMembro");
+    }
+
+    private void possuiPermissaoDeAdmin(UUID idUsuarioAtual, Grupo grupo) {
         if (!grupo.getAdminId().equals(idUsuarioAtual)) {
-            throw APIException.build(HttpStatus.UNAUTHORIZED,"Usuário não autorizado para realizar alterações neste grupo.");
+            throw APIException.build(HttpStatus.UNAUTHORIZED, "Usuário não autorizado para realizar alterações neste grupo.");
         }
     }
 }

--- a/src/main/java/com/divertech/raxae/grupo/application/service/GrupoService.java
+++ b/src/main/java/com/divertech/raxae/grupo/application/service/GrupoService.java
@@ -3,13 +3,13 @@ package com.divertech.raxae.grupo.application.service;
 import com.divertech.raxae.grupo.application.controller.GrupoEditaRequest;
 import com.divertech.raxae.grupo.application.controller.GrupoNovoRequest;
 import com.divertech.raxae.grupo.application.controller.GrupoResponse;
-
 import java.util.UUID;
 
 public interface GrupoService {
-    void deletarGrupo(UUID idDoGrupo, UUID id);
     GrupoResponse criaGrupo(GrupoNovoRequest grupoRequest);
-    GrupoResponse getGrupoById(UUID idDoGrupo, UUID id);
-    void editarGrupo(UUID idDoGrupo, GrupoEditaRequest grupoEditaRequest, UUID id);
-    void removerMembro(UUID idDoGrupo, UUID idDoMembro, UUID id);
+    void deletarGrupo(UUID idDoGrupo, UUID idUsuarioAtual);
+    GrupoResponse getGrupoById(UUID idDoGrupo, UUID idUsuarioAtual);
+    void editarGrupo(UUID idDoGrupo, GrupoEditaRequest grupoEditaRequest, UUID idUsuarioAtual);
+    void removerMembro(UUID idDoGrupo, UUID idDoMembro, UUID idUsuarioAtual);
+    void adicionarMembro(UUID idGrupo, String emailNovoMembro);
 }

--- a/src/main/java/com/divertech/raxae/grupo/domain/Grupo.java
+++ b/src/main/java/com/divertech/raxae/grupo/domain/Grupo.java
@@ -3,52 +3,63 @@ package com.divertech.raxae.grupo.domain;
 import com.divertech.raxae.cobranca.domain.Despesa;
 import com.divertech.raxae.grupo.application.controller.GrupoEditaRequest;
 import com.divertech.raxae.grupo.application.controller.GrupoNovoRequest;
+import com.divertech.raxae.handler.APIException;
+import com.divertech.raxae.usuario.domain.Usuario;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-@Entity
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Data
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
+@Entity
 public class Grupo {
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(columnDefinition = "uuid", updatable = false, unique = true, nullable = false)
     private UUID id;
+
     @NotBlank
     @Column(unique = true)
     private String nomeGrupo;
+
     @NotBlank
     private String descricao;
+
     @NotBlank
     private String icone;
+
     @NotNull
-    private UUID adminId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Usuario administrador;
+
     private LocalDateTime dataCriacao;
+
     @OneToMany
     @JoinColumn(name = "grupo_id")
-    private List<Despesa> despesas;
-    @OneToMany(mappedBy = "grupo", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Membro> membros;
+    private List<Despesa> despesas = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "grupo", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<Membro> membros = new HashSet<>();
 
     public Grupo(GrupoNovoRequest grupoRequest) {
         this.nomeGrupo = grupoRequest.getNomeGrupo();
         this.descricao = grupoRequest.getDescricao();
         this.icone = grupoRequest.getIcone();
-        this.adminId = UUID.fromString(grupoRequest.getIdUserAdmin());
         this.dataCriacao = LocalDateTime.now();
-        this.despesas = new ArrayList<>();
-        this.membros = new ArrayList<>();
     }
 
     public void atualizaInformacoes(GrupoEditaRequest grupoEditaRequest) {
@@ -62,12 +73,35 @@ public class Grupo {
             this.icone = grupoEditaRequest.getIcone();
         }
     }
+
     public void removeMembro(UUID idDoMembro) {
-        for (Membro membro : membros) {
-            if (membro.getUsuario().getId().equals(idDoMembro)) {
-                membro.removeMembro();
-                break;
-            }
+        this.membros.removeIf(membro -> membro.getUsuario().getId().equals(idDoMembro));
+    }
+
+    public void adicionaNovoMembro(Usuario usuario) {
+        boolean jaEhMembro = this.membros.stream()
+            .anyMatch(membro -> membro.getUsuario().getId().equals(usuario.getId()));
+            
+        if (jaEhMembro) {
+            throw APIException.build(HttpStatus.BAD_REQUEST, "Este usuário já faz parte do grupo.");
         }
+        
+        Membro novoMembro = Membro.builder()
+            .usuario(usuario)
+            .grupo(this)
+            .status(StatusParticipacao.PENDENTE)
+            .build();
+            
+        this.membros.add(novoMembro);
+    }
+    
+    public boolean isAdmin(String email) {
+        if (this.administrador == null) return false;
+        return this.administrador.getEmail().equalsIgnoreCase(email);
+    }
+    
+    public UUID getAdminId() {
+        if (this.administrador == null) return null;
+        return this.administrador.getId();
     }
 }

--- a/src/main/java/com/divertech/raxae/grupo/domain/Membro.java
+++ b/src/main/java/com/divertech/raxae/grupo/domain/Membro.java
@@ -2,38 +2,33 @@ package com.divertech.raxae.grupo.domain;
 
 import com.divertech.raxae.usuario.domain.Usuario;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Entity
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Data
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
+@Entity
 public class Membro {
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(columnDefinition = "uuid", updatable = false, unique = true, nullable = false)
     private UUID id;
-    @ManyToOne
-    @JoinColumn(name = "usuario_id")
-    private Usuario usuario;
-    @ManyToOne
-    @JoinColumn(name = "grupo_id")
-    private Grupo grupo;
-    @Enumerated(EnumType.STRING)
-    private StatusParticipacao statusParticipacao;
-    private LocalDateTime dataEntrada;
-    private LocalDateTime dataCriacao;
 
-    public void removeMembro() {
-        if(this.statusParticipacao == StatusParticipacao.REMOVIDO) {
-            return;
-        }
-        this.statusParticipacao = StatusParticipacao.REMOVIDO;
-    }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grupo_id", nullable = false)
+    private Grupo grupo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusParticipacao status;
 }

--- a/src/main/java/com/divertech/raxae/grupo/domain/StatusParticipacao.java
+++ b/src/main/java/com/divertech/raxae/grupo/domain/StatusParticipacao.java
@@ -2,5 +2,5 @@ package com.divertech.raxae.grupo.domain;
 
 
 public enum StatusParticipacao {
-    ATIVO, REMOVIDO
+    ATIVO, PENDENTE,REMOVIDO
 }

--- a/src/main/java/com/divertech/raxae/usuario/application/repository/UsuarioRepository.java
+++ b/src/main/java/com/divertech/raxae/usuario/application/repository/UsuarioRepository.java
@@ -1,8 +1,12 @@
 package com.divertech.raxae.usuario.application.repository;
 
 import com.divertech.raxae.usuario.domain.Usuario;
+import java.util.UUID;
 
 public interface UsuarioRepository {
     void salva(Usuario usuario);
-    Usuario buscaUsuario(String email);
+    Usuario buscaUsuarioPorEmail(String email);
+    Usuario buscaUsuarioPorId(UUID id);
+    long count();
+    void saveAll(Iterable<Usuario> usuarios);
 }

--- a/src/main/java/com/divertech/raxae/usuario/domain/Usuario.java
+++ b/src/main/java/com/divertech/raxae/usuario/domain/Usuario.java
@@ -7,10 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,27 +17,35 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
 
-@Entity
-@Getter
+@Data
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Entity
 public class Usuario implements UserDetails {
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(columnDefinition = "uuid", updatable = false, unique = true, nullable = false)
     private UUID id;
+
     @NotBlank(message = "Campo não pode ser em branco")
     private String nomeCompleto;
+
     @Email
     @Column(unique = true)
     private String email;
+
     @NotNull
     @Getter(AccessLevel.NONE)
     @Size(max = 60)
     private String senha;
+
     private TipoPlano tipo;
+
     @NotBlank(message = "Campo não pode ser em branco")
     private String whatsapp;
+
     private LocalDateTime momentoCriacao;
 
     public Usuario(UsuarioRequest usuarioRequest, BCryptPasswordEncoder passwordEncoder) {
@@ -56,26 +61,32 @@ public class Usuario implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList();
     }
+
     @Override
     public String getPassword() {
         return this.senha;
     }
+
     @Override
     public String getUsername() {
         return this.email;
     }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
+
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
+
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
+
     @Override
     public boolean isEnabled() {
         return true;

--- a/src/main/java/com/divertech/raxae/usuario/infra/UsuarioInfraRepository.java
+++ b/src/main/java/com/divertech/raxae/usuario/infra/UsuarioInfraRepository.java
@@ -8,7 +8,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @Log4j2
@@ -23,11 +23,36 @@ public class UsuarioInfraRepository implements UsuarioRepository {
         log.debug("[finish] UsuarioInfraRepository - salva");
     }
 
-    public Usuario buscaUsuario(String email){
-        log.info("[start] UsuarioInfraRepository - findByEmail");
-        Usuario usuario = usuarioSpringDataRepository.findByEmail(email)
-                .orElseThrow(() -> APIException.build(HttpStatus.NOT_FOUND, "Usuário não encontrado!"));
-        log.debug("[finish] UsuarioInfraRepository - findByEmail");
+    @Override
+    public Usuario buscaUsuarioPorEmail(String email) {
+        log.info("[start] UsuarioInfraRepository - buscaUsuarioPorEmail");
+        Usuario usuario = usuarioSpringDataRepository.findByEmail(email.toLowerCase())
+                .orElseThrow(() -> APIException.build(HttpStatus.NOT_FOUND, "Usuário não encontrado para o e-mail: " + email));
+        log.info("[finish] UsuarioInfraRepository - buscaUsuarioPorEmail");
         return usuario;
+    }
+
+    @Override
+    public Usuario buscaUsuarioPorId(UUID id) {
+        log.info("[start] UsuarioInfraRepository - buscaUsuarioPorId");
+        Usuario usuario = usuarioSpringDataRepository.findById(id)
+                .orElseThrow(() -> APIException.build(HttpStatus.NOT_FOUND, "Usuário não encontrado com o ID: " + id));
+        log.debug("[finish] UsuarioInfraRepository - buscaUsuarioPorId");
+        return usuario;
+    }
+
+    @Override
+    public long count() {
+        log.info("[start] UsuarioInfraRepository - count");
+        long total = usuarioSpringDataRepository.count();
+        log.info("[finish] UsuarioInfraRepository - count");
+        return total;
+    }
+
+    @Override
+    public void saveAll(Iterable<Usuario> usuarios) {
+        log.info("[start] UsuarioInfraRepository - saveAll");
+        usuarioSpringDataRepository.saveAll(usuarios);
+        log.info("[finish] UsuarioInfraRepository - saveAll");
     }
 }


### PR DESCRIPTION
Este PR implementa a user story DESP-5, que permite a um administrador de grupo adicionar novos membros informando seus respectivos e-mails. O objetivo é permitir que novos usuários possam ser incluídos no rateio de despesas do grupo.

Para atender aos requisitos, as seguintes alterações foram implementadas:

API:
    -> Criado o endpoint `POST /v1/grupo/{idGrupo}/membros` que aceita um corpo JSON com o e-mail do novo membro.

Lógica de Negócio (Service):
    Adicionada a validação no `GrupoApplicationService` para garantir que apenas o administrador do grupo possa executar a ação.
    Implementado o fluxo para buscar o usuário por e-mail e associá-lo ao grupo como um novo `Membro` com status `PENDENTE`.

Ambiente de Desenvolvimento:
    Criado o componente `DataSeeder` com a anotação `@Profile("dev")` para popular o banco de dados local com usuários de teste (admin, comum e um membro a ser convidado) a cada inicialização da aplicação em modo de desenvolvimento.

Refatoração e Correções:
    Padronização dos métodos de busca por e-mail nos repositórios e serviços do módulo de usuário, centralizando o uso em `buscaUsuarioPorEmail`.
    Correção de diversas entidades e serviços que estavam com código corrompido ou inconsistente após a restauração de um backup.
    Ajustada a entidade `Grupo` para ter uma referência de objeto `@ManyToOne` ao `Usuario` administrador, seguindo as melhores práticas do JPA.